### PR TITLE
Mirror update from go-ecs (2025-07-16 14:51 UTC)

### DIFF
--- a/.github/workflows/tidy.yaml
+++ b/.github/workflows/tidy.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   tidy:
@@ -22,9 +25,28 @@ jobs:
         run: |
           go mod tidy
           if ! git diff --quiet; then
-            git config user.name "Mirror Bot"
-            git config user.email "mirror-bot@github"
-            git add go.mod go.sum
-            git commit -m "chore: tidy go.mod and go.sum"
-            git push
+            # Check if this is a mirror update PR (auto-fix) or regular PR (fail)
+            if [ "${{ github.event_name }}" = "pull_request" ] && [[ "${{ github.head_ref }}" == mirror-update-* ]]; then
+              echo "🔧 Auto-fixing go.mod/go.sum for mirror update PR"
+              git config user.name "Mirror Bot"
+              git config user.email "mirror-bot@github"
+              git add go.mod go.sum
+              git commit -m "chore: tidy go.mod and go.sum for mirror update"
+              git push
+              echo "✅ go.mod and go.sum have been tidied and committed"
+            elif [ "${{ github.event_name }}" = "pull_request" ]; then
+              echo "❌ go.mod or go.sum files are not tidy"
+              echo "Please run 'go mod tidy' locally and commit the changes"
+              git diff
+              exit 1
+            else
+              # Auto-fix on main branch pushes
+              git config user.name "Mirror Bot"
+              git config user.email "mirror-bot@github"
+              git add go.mod go.sum
+              git commit -m "chore: tidy go.mod and go.sum"
+              git push
+            fi
+          else
+            echo "✅ go.mod and go.sum are tidy."
           fi

--- a/cmd/world/cardinal.go
+++ b/cmd/world/cardinal.go
@@ -8,6 +8,7 @@ import (
 	"github.com/argus-labs/go-ecs/internal/app/world-cli/models"
 )
 
+//nolint:gochecknoglobals // standard kong plugin struct
 var CardinalCmdPlugin struct {
 	Cardinal *CardinalCmd `cmd:"" group:"Cardinal Commands:" help:"Manage your Cardinal game shard"`
 }

--- a/cmd/world/cloud.go
+++ b/cmd/world/cloud.go
@@ -7,7 +7,7 @@ import (
 	"github.com/argus-labs/go-ecs/internal/app/world-cli/models"
 )
 
-//nolint:lll // needed to put all the help text in the same line
+//nolint:lll,gochecknoglobals // needed to put all the help text in the same line
 var CloudCmdPlugin struct {
 	Deploy  *DeployCloudCmd  `cmd:"" group:"Cloud Management Commands:" help:"Deploy your World Forge project to a TEST environment in the cloud"`
 	Status  *StatusCloudCmd  `cmd:"" group:"Cloud Management Commands:" help:"Check the status of your deployed World Forge project"`

--- a/cmd/world/evm.go
+++ b/cmd/world/evm.go
@@ -7,6 +7,7 @@ import (
 	"github.com/argus-labs/go-ecs/internal/app/world-cli/models"
 )
 
+//nolint:gochecknoglobals // standard kong plugin struct
 var EvmCmdPlugin struct {
 	Evm *EvmCmd `cmd:"" group:"EVM Commands:" help:"Manage your EVM blockchain environment"`
 }

--- a/cmd/world/main.go
+++ b/cmd/world/main.go
@@ -56,6 +56,7 @@ const (
 	go build -ldflags "-X main.PosthogAPIKey=<POSTHOG_API_KEY>
 							-X main.SentryDsn=<SENTRY_DSN>>"
 */
+//nolint:gochecknoglobals // Only used for ldflags
 var (
 	PosthogAPIKey string
 	SentryDsn     string
@@ -134,7 +135,7 @@ func main() {
 
 	// Set verbose mode if the flag is enabled
 	if CLI.Verbose {
-		logger.VerboseMode = true
+		logger.SetVerboseMode(true)
 	}
 
 	realCtx := contextWithSigterm(context.Background())

--- a/cmd/world/organization.go
+++ b/cmd/world/organization.go
@@ -7,6 +7,7 @@ import (
 	"github.com/argus-labs/go-ecs/internal/app/world-cli/models"
 )
 
+//nolint:gochecknoglobals // standard kong plugin struct
 var OrganizationCmdPlugin struct {
 	Organization *OrganizationCmd `cmd:"" aliases:"org"  group:"Organization Commands:" help:"Manage your organizations"`
 }

--- a/cmd/world/project.go
+++ b/cmd/world/project.go
@@ -7,6 +7,7 @@ import (
 	"github.com/argus-labs/go-ecs/internal/app/world-cli/models"
 )
 
+//nolint:gochecknoglobals // standard kong plugin struct
 var ProjectCmdPlugin struct {
 	Project *ProjectCmd `cmd:"" aliases:"proj" group:"Project Commands:"      help:"Manage your projects"`
 }

--- a/cmd/world/root.go
+++ b/cmd/world/root.go
@@ -7,6 +7,7 @@ import (
 	cmdsetup "github.com/argus-labs/go-ecs/internal/app/world-cli/controllers/cmd_setup"
 )
 
+//nolint:gochecknoglobals // standard kong plugin struct
 var CLI RootCmd
 
 //nolint:lll // must be on one line

--- a/cmd/world/user.go
+++ b/cmd/world/user.go
@@ -7,6 +7,7 @@ import (
 	"github.com/argus-labs/go-ecs/internal/app/world-cli/models"
 )
 
+//nolint:gochecknoglobals // standard kong plugin struct
 var UserCmdPlugin struct {
 	User *UserCmd `cmd:""`
 }

--- a/internal/pkg/logger/init.go
+++ b/internal/pkg/logger/init.go
@@ -50,6 +50,10 @@ func init() {
 	log.Logger = lgr
 }
 
+func SetVerboseMode(verbose bool) {
+	VerboseMode = verbose
+}
+
 // PrintLogs print all stacked log.
 func PrintLogs() {
 	if VerboseMode {


### PR DESCRIPTION
🤖 Automated mirror update from the main go-ecs repository.

This PR contains the latest changes from the world-cli components in the go-ecs repository.

**Source Commit:** `2c8d2b627e95e29c5be9e26e80758a5cdc8bb812`

**Changes included:**
- Updated world-cli code
- Updated dependencies and go.mod/go.sum  
- Updated internal packages (logger, printer, tea)

This PR will auto-merge once all required checks pass, including the `gomodtidy` check.
